### PR TITLE
Update check-spelling to lastest version

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -50,20 +50,21 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.20
+        uses: check-spelling/check-spelling@v0.0.21
         with:
           suppress_push_for_open_pull_request: 1
           checkout: true
           spell_check_this: check-spelling/spell-check-this@prerelease
           post_comment: 0
           experimental_apply_changes_via_bot: 1
-          extra_dictionaries:
-            cspell:filetypes/filetypes.txt
-            cspell:software-terms/softwareTerms.txt
-            cspell:companies/companies.txt
+          dictionary_source_prefixes: '{"cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20220816/dictionaries/"}'
+          extra_dictionaries: cspell:filetypes/filetypes.txt
+            cspell:software-terms/src/software-terms.txt
+            cspell:companies/src/companies.txt
             cspell:haskell/haskell.txt
             cspell:html/html.txt
             cspell:aws/aws.txt
+          check_extra_dictionaries: ""
 
   comment:
     name: Report
@@ -89,9 +90,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     if: ${{
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@check-spelling-bot apply')
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@check-spelling-bot apply')
       }}
     concurrency:
       group: spelling-update-${{ github.event.issue.number }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -58,13 +58,13 @@ jobs:
           post_comment: 0
           experimental_apply_changes_via_bot: 1
           dictionary_source_prefixes: '{"cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20220816/dictionaries/"}'
-          extra_dictionaries: cspell:filetypes/filetypes.txt
+          extra_dictionaries: 
+            cspell:filetypes/filetypes.txt
             cspell:software-terms/src/software-terms.txt
             cspell:companies/src/companies.txt
             cspell:haskell/haskell.txt
             cspell:html/html.txt
             cspell:aws/aws.txt
-          check_extra_dictionaries: ""
 
   comment:
     name: Report


### PR DESCRIPTION
check-spelling version 0.0.20 uses the deprecated `:set-output:` workflow command, which will be [disabled on 31st May](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). Workflows using these commands will then fail with an error.

check-spelling version 0.0.21 ([Release notes](https://github.com/check-spelling/check-spelling/releases/tag/v0.0.21)) addresses this issue. 

**Changes**

- update check-spelling to version 0.0.21
- update check-spelling workflow to satisfy the new configuration changes
- update dictionary URLs

P.S.: I know this probably won't count towards the leader board. However, I still wanted to fix this since I noticed the warnings.